### PR TITLE
Add in-browser harmonic preset editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-toastify": "^11.0.5",
-    "style-props-html": "^0.0.6"
+    "style-props-html": "^0.0.6",
+    "monaco-editor": "^0.45.0",
+    "monaco-react": "^4.4.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/public/presets.json
+++ b/public/presets.json
@@ -1,0 +1,4 @@
+{
+  "jazz-organ": "presets/jazz-organ.js",
+  "tiney": "presets/tiney.js"
+}

--- a/public/presets/tiney.js
+++ b/public/presets/tiney.js
@@ -1,25 +1,23 @@
 import { normalizeNXODef } from "../nxo.js";
 
-const harms = {}
-
-for(let i=1; i<=3; i++) {
+const harms = {};
+for (let i = 1; i <= 3; i++) {
   harms[i] = {
-    amplitude: 1/i,
-    attack: (i-1+0.50)/5,
-    decay: 2/i,
+    amplitude: 1 / i,
+    attack: (i - 1 + 0.5) / 5,
+    decay: 2 / i,
     sustain: 0,
-    release: 0.5/i,
-  }
+    release: 0.5 / i,
+  };
 }
-
-for(let i=1; i<=3; i++) {
-  harms[i+0.5] = {
-    amplitude: 0.5/i,
+for (let i = 1; i <= 3; i++) {
+  harms[i + 0.5] = {
+    amplitude: 0.5 / i,
     attack: 0.005,
-    decay: 2/i,
+    decay: 2 / i,
     sustain: 0,
-    release: 0.5/i,
-  }
+    release: 0.5 / i,
+  };
 }
 
-export default normalizeNXODef(harms)
+export default normalizeNXODef(harms);


### PR DESCRIPTION
## Summary
- integrate monaco-react code editor
- fetch presets list from `presets.json`
- allow compiling custom JavaScript to update the NXO processor
- restructure layout to show editor alongside piano widget

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TypeScript errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f5096c5f08329b83649958616be0e