### PR TITLE
Add simple recording widget

### DIFF
--- a/src/Recorder.tsx
+++ b/src/Recorder.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface RecorderProps {
+  stream: MediaStream | null;
+  memoryLimitBytes: number;
+}
+
+export default function Recorder({ stream, memoryLimitBytes }: RecorderProps) {
+  const [recording, setRecording] = useState(false);
+  const [url, setUrl] = useState<string | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const sizeRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [url]);
+
+  const start = useCallback(() => {
+    if (!stream) return;
+    if (recording) return;
+    chunksRef.current = [];
+    sizeRef.current = 0;
+    const mr = new MediaRecorder(stream);
+    mr.ondataavailable = (e) => {
+      if (!e.data || e.data.size === 0) return;
+      const nextSize = sizeRef.current + e.data.size;
+      if (nextSize > memoryLimitBytes) {
+        mr.stop();
+        return;
+      }
+      chunksRef.current.push(e.data);
+      sizeRef.current = nextSize;
+    };
+    mr.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: mr.mimeType });
+      if (url) URL.revokeObjectURL(url);
+      setUrl(URL.createObjectURL(blob));
+      setRecording(false);
+    };
+    mr.start();
+    mediaRecorderRef.current = mr;
+    setRecording(true);
+  }, [stream, memoryLimitBytes, recording, url]);
+
+  const stop = useCallback(() => {
+    mediaRecorderRef.current?.stop();
+  }, []);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+      <button onClick={recording ? stop : start} disabled={!stream}>
+        {recording ? "Stop Recording" : "Start Recording"}
+      </button>
+      {url && (
+        <audio controls src={url} />
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create basic React component to record audio via MediaRecorder
- wire up App.tsx to create a MediaStream from the synth and display Recorder widget
- limit recording memory usage based on available device memory

## Testing
- `npm run build` *(fails: cannot find module due to missing packages)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f6e332da08329813c75eb5eb3c9fe